### PR TITLE
feat/view-details

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -463,6 +463,7 @@
   <body
     class="gradient template-{{ template | split: '.' | first }} {{ template }}{% if template == "product" %} {{ product.handle }}{% endif %} {% for tag in product.tags %} {{ tag }}{% endfor %}"
     data-sticky-original
+		data-view-details="false"
   >
   {% render 'sticky-atc' %}
     <a class="skip-to-content-link button visually-hidden" href="#MainContent">

--- a/sections/section-installments.liquid
+++ b/sections/section-installments.liquid
@@ -40,4 +40,47 @@
 
     button.click();
   });
+
+  const closeModal = () => {
+    const paymentTermsModal = document.getElementById('shopify-payment-terms-cover');
+
+    if (paymentTermsModal) {
+      paymentTermsModal.addEventListener('click', () => {
+        const closeButton = paymentTermsModal
+          .querySelector('div')
+          .querySelector('shopify-installments-prequal-modal')
+          .shadowRoot.querySelector('#shopify-payment-terms-modal')
+          .querySelector('section')
+          .querySelector('header')
+          .querySelector('#header-icons')
+          .querySelector('button');
+
+        closeButton.click();
+      });
+    }
+  };
+
+  // Arrow function to observe DOM changes
+  const observeDOMChanges = () => {
+    const targetNode = document.body;
+    const config = { childList: true, subtree: true };
+
+    const callback = (mutationsList, observer) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+          const addedNodes = mutation.addedNodes;
+          for (const node of addedNodes) {
+            if (node.nodeType === Node.ELEMENT_NODE && node.id === 'shopify-payment-terms-cover') {
+              closeModal();
+            }
+          }
+        }
+      }
+    };
+
+    const observer = new MutationObserver(callback);
+    observer.observe(targetNode, config);
+  };
+
+  observeDOMChanges();
 {% endjavascript %}

--- a/sections/section-installments.liquid
+++ b/sections/section-installments.liquid
@@ -2,7 +2,8 @@
   <div class="container">
     <div class="installments-inner">
       <h2>Pay in 4 interest-free installments—from $20.67/mo</h2>
-      <button id="button-view-details" class="bf-add-cart-btn btn-custom button">View details</button>
+      {% comment %} <button id="button-view-details" class="bf-add-cart-btn btn-custom button">View details</button> {% endcomment %}
+      <button id="button-view-details" class="bf-add-cart-btn btn-custom button">View plans</button>
 
       <div class="hidden">
         {%- assign product_form_installment_id = 'product-form-installment-' | append: section.id -%}
@@ -31,57 +32,79 @@
 {% endstylesheet %}
 
 {% javascript %}
-  document.getElementById('button-view-details').addEventListener('click', () => {
-    let button = document
-      .querySelector('shopify-payment-terms')
-      .shadowRoot.querySelector('shop-pay-installments-banner')
-      .shadowRoot.querySelector('#shopify-installments')
-      .querySelector('#shopify-installments-cta');
+  const newFeatureViewDetails = () => {
+    document.getElementById('button-view-details').addEventListener('click', () => {
+      let button = document
+        .querySelector('shopify-payment-terms')
+        .shadowRoot.querySelector('shop-pay-installments-banner')
+        .shadowRoot.querySelector('#shopify-installments')
+        .querySelector('#shopify-installments-cta');
 
-    button.click();
-  });
+      button.click();
+    });
 
-  const closeModal = () => {
-    const paymentTermsModal = document.getElementById('shopify-payment-terms-cover');
+    const closeModal = () => {
+      const paymentTermsModal = document.getElementById('shopify-payment-terms-cover');
 
-    if (paymentTermsModal) {
-      paymentTermsModal.addEventListener('click', (event) => {
-        const clickedElement = event.target;
+      if (paymentTermsModal) {
+        paymentTermsModal.addEventListener('click', (event) => {
+          const clickedElement = event.target;
 
-        const excludedTagName = 'shopify-installments-prequal-modal';
+          const excludedTagName = 'shopify-installments-prequal-modal';
 
-        if (!clickedElement.closest(excludedTagName)) {
-          const closeButton = paymentTermsModal
-            .querySelector('div shopify-installments-prequal-modal')
-            ?.shadowRoot.querySelector('#shopify-payment-terms-modal button');
+          if (!clickedElement.closest(excludedTagName)) {
+            const closeButton = paymentTermsModal
+              .querySelector('div shopify-installments-prequal-modal')
+              ?.shadowRoot.querySelector('#shopify-payment-terms-modal button');
 
-          if (closeButton) {
-            closeButton.click();
-          }
-        }
-      });
-    }
-  };
-
-  const observeDOMChanges = () => {
-    const targetNode = document.body;
-    const config = { childList: true, subtree: true };
-
-    const callback = (mutationsList, observer) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'childList') {
-          for (const node of mutation.addedNodes) {
-            if (node.nodeType === Node.ELEMENT_NODE && node.id === 'shopify-payment-terms-cover') {
-              closeModal();
+            if (closeButton) {
+              closeButton.click();
             }
           }
-        }
+        });
       }
     };
 
-    const observer = new MutationObserver(callback);
-    observer.observe(targetNode, config);
+    const observeDOMChanges = () => {
+      const targetNode = document.body;
+      const config = { childList: true, subtree: true };
+
+      const callback = (mutationsList, observer) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList') {
+            for (const node of mutation.addedNodes) {
+              if (node.nodeType === Node.ELEMENT_NODE && node.id === 'shopify-payment-terms-cover') {
+                closeModal();
+              }
+            }
+          }
+        }
+      };
+
+      const observer = new MutationObserver(callback);
+      observer.observe(targetNode, config);
+    };
+
+    observeDOMChanges();
   };
 
-  observeDOMChanges();
+  const targetNode = document.body;
+
+  const config = { attributes: true, attributeFilter: ['data-view-details'] };
+
+  const callback = function (mutationsList, observer) {
+    for (let mutation of mutationsList) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'data-view-details') {
+        const newValue = mutation.target.getAttribute('data-view-details');
+        if (newValue === 'true') {
+          document.getElementById('button-view-details').innerText = 'View details';
+          newFeatureViewDetails();
+        }
+      }
+    }
+  };
+
+  const observer = new MutationObserver(callback);
+
+  observer.observe(targetNode, config);
 {% endjavascript %}

--- a/sections/section-installments.liquid
+++ b/sections/section-installments.liquid
@@ -1,28 +1,43 @@
 <div class="installments">
   <div class="container">
     <div class="installments-inner">
-    <h2>Pay in 4 interest-free installments—from $20.67/mo</h2>
-      <a href="#" class="bf-add-cart-btn btn-custom button">View plans</a>
+      <h2>Pay in 4 interest-free installments—from $20.67/mo</h2>
+      <button id="button-view-details" class="bf-add-cart-btn btn-custom button">View details</button>
+
+      <div class="hidden">
+        {%- assign product_form_installment_id = 'product-form-installment-' | append: section.id -%}
+        {%- form 'product', product, id: product_form_installment_id, class: 'installment caption-large' -%}
+          <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}">
+          {{ form | payment_terms }}
+        {%- endform -%}
+      </div>
     </div>
   </div>
-  
 </div>
 
-
 {% schema %}
-  {
-    "name": "Installments",
-    "settings": [],
-    "presets": [
-      {
-        "name": "Installments"
-      }
-    ]
-  }
+{
+  "name": "Installments",
+  "settings": [],
+  "presets": [
+    {
+      "name": "Installments"
+    }
+  ]
+}
 {% endschema %}
 
 {% stylesheet %}
 {% endstylesheet %}
 
 {% javascript %}
+  document.getElementById('button-view-details').addEventListener('click', () => {
+    let button = document
+      .querySelector('shopify-payment-terms')
+      .shadowRoot.querySelector('shop-pay-installments-banner')
+      .shadowRoot.querySelector('#shopify-installments')
+      .querySelector('#shopify-installments-cta');
+
+    button.click();
+  });
 {% endjavascript %}

--- a/sections/section-installments.liquid
+++ b/sections/section-installments.liquid
@@ -45,22 +45,24 @@
     const paymentTermsModal = document.getElementById('shopify-payment-terms-cover');
 
     if (paymentTermsModal) {
-      paymentTermsModal.addEventListener('click', () => {
-        const closeButton = paymentTermsModal
-          .querySelector('div')
-          .querySelector('shopify-installments-prequal-modal')
-          .shadowRoot.querySelector('#shopify-payment-terms-modal')
-          .querySelector('section')
-          .querySelector('header')
-          .querySelector('#header-icons')
-          .querySelector('button');
+      paymentTermsModal.addEventListener('click', (event) => {
+        const clickedElement = event.target;
 
-        closeButton.click();
+        const excludedTagName = 'shopify-installments-prequal-modal';
+
+        if (!clickedElement.closest(excludedTagName)) {
+          const closeButton = paymentTermsModal
+            .querySelector('div shopify-installments-prequal-modal')
+            ?.shadowRoot.querySelector('#shopify-payment-terms-modal button');
+
+          if (closeButton) {
+            closeButton.click();
+          }
+        }
       });
     }
   };
 
-  // Arrow function to observe DOM changes
   const observeDOMChanges = () => {
     const targetNode = document.body;
     const config = { childList: true, subtree: true };
@@ -68,8 +70,7 @@
     const callback = (mutationsList, observer) => {
       for (const mutation of mutationsList) {
         if (mutation.type === 'childList') {
-          const addedNodes = mutation.addedNodes;
-          for (const node of addedNodes) {
+          for (const node of mutation.addedNodes) {
             if (node.nodeType === Node.ELEMENT_NODE && node.id === 'shopify-payment-terms-cover') {
               closeModal();
             }


### PR DESCRIPTION
# MIR- “View Plans” to “View Details” (A/B Test) - [Reference](https://app.clickup.com/t/86drw9pdh)
---
The name of the button was changed to 'view details' and it was added so that when I clicked it it would open the 'check your purchasing' modal

## Type of pull request
- [x] New Feature
- [ ] Bugfixes
- [ ] Release
- [ ] Cleanup
- [ ] Other (You must specify)

## Work Done
- 

## Screenshots
<img width="960" alt="image" src="https://github.com/Endrock/mira/assets/46056747/598ee283-dcaa-4f9d-8228-2237fc7a4449">

<img width="728" alt="image" src="https://github.com/Endrock/mira/assets/46056747/3a9326bf-6629-40b4-ad7d-b9bf02967c25">


## Preview link
https://shop.miracare.com/en-int/products/fertility-max-starter-kit?preview_theme_id=166008783141